### PR TITLE
fix: `cards` — visible `scrollbar-width` on firefox

### DIFF
--- a/src/assets/scss/modules/component/_card.scss
+++ b/src/assets/scss/modules/component/_card.scss
@@ -69,6 +69,7 @@
     flex-wrap: wrap;
     gap: 1rem;
     margin-top: 2rem;
+    scrollbar-width: none;
 
     &.nocentered {
       justify-content: flex-start;


### PR DESCRIPTION
Close #160 