### PR TITLE
fix: `redirect` — improper not found page for `/blog`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,11 @@
   status = 200
 
 [[redirects]]
+  from = "/blog/*"
+  to = "/error"
+  status = 404
+
+[[redirects]]
   from = "/*"
   to = "/error"
   status = 404


### PR DESCRIPTION
Close #176 