### PR TITLE
fix: `blog` — redirect `blog/{slug}/invalid` not found

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,13 +3,18 @@
 
 [[redirects]]
   from = "/blog/*"
-  to = "/articles/blog/:splat"
-  status = 200
+  to = "/error"
+  status = 404
+
+[[redirects]]
+  from = "/blog/*/*"
+  to = "/error"
+  status = 404
 
 [[redirects]]
   from = "/blog/*"
-  to = "/error"
-  status = 404
+  to = "/articles/blog/:splat"
+  status = 200
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
close #193 