### PR TITLE
fix: `netlify.toml` — fix accessing /blog/* redirecting to /error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,16 +3,6 @@
 
 [[redirects]]
   from = "/blog/*"
-  to = "/error"
-  status = 404
-
-[[redirects]]
-  from = "/blog/*/*"
-  to = "/error"
-  status = 404
-
-[[redirects]]
-  from = "/blog/*"
   to = "/articles/blog/:splat"
   status = 200
 
@@ -20,6 +10,16 @@
   from = "/signatures/*"
   to = "/images/signatures/:splat"
   status = 200
+
+[[redirects]]
+  from = "/blog/*"
+  to = "/error"
+  status = 404
+
+[[redirects]]
+  from = "/blog/*/*"
+  to = "/error"
+  status = 404
 
 [[redirects]]
   from = "/*"


### PR DESCRIPTION
After #194, all post links that use `/blog/` instead of `/articles/blog` will be redirect to `/error`