### PR TITLE
fix: `article.njk` — update invalid reference for css

### DIFF
--- a/src/_includes/article.njk
+++ b/src/_includes/article.njk
@@ -1,6 +1,6 @@
 ---
 layout: 'layouts/secondary.njk'
-style: 'use/article.css'
+style: 'article.css'
 ---
 {% set previousPost = collections.post | getPreviousCollectionItem(page) %}
 {% set nextPost = collections.post | getNextCollectionItem(page) %}


### PR DESCRIPTION
A missed implementation in #212