### PR TITLE
update: `bin*.bat` — support alias with path ref

### DIFF
--- a/ewtools.bat
+++ b/ewtools.bat
@@ -1,2 +1,3 @@
 @echo off
-node ./bin/ewTools.js %*
+set SCRIPT_DIR=%~dp0
+node %SCRIPT_DIR%/bin/ewTools.js %*

--- a/ewtools.class.bat
+++ b/ewtools.class.bat
@@ -1,2 +1,3 @@
 @echo off
-node ./bin/ewTools.class.js %*
+set SCRIPT_DIR=%~dp0
+node %SCRIPT_DIR%/bin/ewTools.class.js %*


### PR DESCRIPTION
The purpose of this PR, is to make it possible for the bin to run only on the "currentDirectory" of the code, so no reference problem for powershell aliases.